### PR TITLE
Fixed Reconciliation Loop

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,26 +1,27 @@
-# Build the manager binary
-FROM docker.io/golang:1.23
-ARG TARGETOS
-ARG TARGETARCH
+ARG GOLANG_VERSION=1.23
+
+# Build container should always be on the native build platform.
+FROM --platform=$BUILDPLATFORM golang:${GOLANG_VERSION} AS builder
+
+WORKDIR /src
+
+ARG TARGETOS TARGETARCH
+
+RUN --mount=type=bind,source=go.sum,target=go.sum \
+    --mount=type=bind,source=go.mod,target=go.mod \
+    go mod download -x
+
+# Mount the source code into the build container and build the binary.
+RUN --mount=type=bind,target=. \
+    CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=$TARGETARCH \
+    go build -v -o /go/bin/manager cmd/main.go
+
+FROM scratch
+
+USER 65532:65532
 
 WORKDIR /workspace
-# Copy the Go Modules manifests
-COPY go.mod go.mod
-COPY go.sum go.sum
-# cache deps before building and copying source so that we don't need to re-download as much
-# and so that source changes don't invalidate our downloaded layer
-RUN go mod download
 
-# Copy the go source
-COPY cmd/main.go cmd/main.go
-COPY api/ api/
-COPY internal/ internal/
+COPY --from=builder /go/bin/manager /workspace/manager
 
-# Build
-# the GOARCH has not a default value to allow the binary be built according to the host where the command
-# was called. For example, if we call make docker-build in a local env which has the Apple Silicon M1 SO
-# the docker BUILDPLATFORM arg will be linux/arm64 when for Apple x86 it will be linux/amd64. Therefore,
-# by leaving it empty we can ensure that the container and binary shipped on it will have the same platform.
-RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o manager cmd/main.go
-USER 65532:65532
 ENTRYPOINT ["/workspace/manager"]

--- a/internal/controller/podlogmonitor_controller.go
+++ b/internal/controller/podlogmonitor_controller.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,31 +16,31 @@ limitations under the License.
 package controller
 
 import (
-        "context"
-        "strings"
-        "time"
+	"context"
+	"strings"
+	"time"
 
-        corev1 "k8s.io/api/core/v1"
-        metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-        "k8s.io/client-go/kubernetes"
-        "k8s.io/apimachinery/pkg/runtime"
-        "k8s.io/client-go/rest"
-        ctrl "sigs.k8s.io/controller-runtime"
-        "sigs.k8s.io/controller-runtime/pkg/client"
-        "sigs.k8s.io/controller-runtime/pkg/log"
-        "sigs.k8s.io/controller-runtime/pkg/reconcile"
-        "github.com/go-logr/logr"
+	"github.com/go-logr/logr"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
-        monitoringv1 "mydomain.com/m/api/v1"
+	monitoringv1 "mydomain.com/m/api/v1"
 )
 
 // PodLogMonitorReconciler reconciles a PodLogMonitor object
 type PodLogMonitorReconciler struct {
-        client.Client
-        Scheme *runtime.Scheme
-        Log logr.Logger
-        clientset *kubernetes.Clientset
+	client.Client
+	Scheme    *runtime.Scheme
+	Log       logr.Logger
+	clientset *kubernetes.Clientset
 }
 
 // +kubebuilder:rbac:groups=monitoring.mydomain.com,resources=podlogmonitors,verbs=get;list;watch;create;update;patch;delete
@@ -57,107 +57,94 @@ type PodLogMonitorReconciler struct {
 // For more details, check Reconcile and its Result here:
 // - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.20.0/pkg/reconcile
 func (r *PodLogMonitorReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-        _ = log.FromContext(ctx)
+	logger := log.FromContext(ctx).WithValues("podlogmonitor", req.NamespacedName)
 
-        log := r.Log.WithValues("podlogmonitor", req.NamespacedName)
-        log.Info("Line - 1")
-        // Fetch the PodLogMonitor resource
-        var podLogMonitor monitoringv1.PodLogMonitor
-        if err := r.Get(ctx, req.NamespacedName, &podLogMonitor); err != nil {
-                log.Error(err, "unable to fetch PodLogMonitor")
-                return reconcile.Result{}, client.IgnoreNotFound(err)
-        }
+	// Fetch the PodLogMonitor resource
+	var podLogMonitor monitoringv1.PodLogMonitor
+	if err := r.Get(ctx, req.NamespacedName, &podLogMonitor); err != nil {
+		logger.Error(err, "unable to fetch PodLogMonitor")
+		return reconcile.Result{}, client.IgnoreNotFound(err)
+	}
 
-        log.Info("Line - 2")
-        // Fetch Pod logs from the specified namespace
-        podList := &corev1.PodList{}
-        if err := r.List(ctx, podList, client.MatchingLabels{"someLabel": podLogMonitor.Spec.Namespace}); err != nil {
-        //if err := r.List(ctx, podList, client.InNamespace(podLogMonitor.Spec.Namespace)); err != nil {
-                log.Error(err, "unable to list pods")
-                return reconcile.Result{}, err
-        }
+	// Fetch Pod logs from the specified namespace
+	var podList corev1.PodList
+	if err := r.List(ctx, &podList, client.InNamespace(podLogMonitor.Spec.Namespace)); err != nil {
+		logger.Error(err, "unable to list pods")
+		return reconcile.Result{}, err
+	}
 
-        log.Info("Line - 3")
-        // Iterate over the pods and check logs
-        for _, pod := range podList.Items {
-                log.Info("In the for loop")
-                if err := r.checkPodLogs(ctx, &pod, podLogMonitor.Spec.LogMessage, &podLogMonitor); err != nil {
-                log.Error(err, "unable to check pod logs", "pod", pod.Name)
-                continue
-                }
-        }
+	// Iterate over the pods and check logs
+	for _, pod := range podList.Items {
+		logger.Info("found pod", "pod", pod)
 
-        log.Info("Line - 4")
-        // Save the updated status
-        if err := r.Status().Update(ctx, &podLogMonitor); err != nil {
-                log.Error(err, "unable to update PodLogMonitor status")
-                return reconcile.Result{}, err
-        }
-        log.Info("Line - 5")
-        // Return after processing
-        return reconcile.Result{}, nil
+		if err := r.checkPodLogs(ctx, &pod, podLogMonitor.Spec.LogMessage, &podLogMonitor); err != nil {
+			logger.Error(err, "unable to check pod logs", "pod", pod.Name)
+			continue
+		}
+	}
+
+	// Return after processing
+	return reconcile.Result{}, nil
 }
-
 
 func (r *PodLogMonitorReconciler) checkPodLogs(ctx context.Context, pod *corev1.Pod, logMessage string, podLogMonitor *monitoringv1.PodLogMonitor) error {
-   log := r.Log.WithValues("pod", pod.Name)
-   log.Info("Line - 6")
-   // Check if we have the clientset; if not, create it
-    if r.clientset == nil {
-        log.Info("Creating a new clientset...")
-        config, err := rest.InClusterConfig()
-        if err != nil {
-            log.Error(err, "unable to create in-cluster config")
-            return err
-        }
-        clientset, err := kubernetes.NewForConfig(config)
-        if err != nil {
-            log.Error(err, "unable to create Kubernetes clientset")
-            return err
-        }
-        r.clientset = clientset
-    }
-   // Get the logs of the pod using the Kubernetes API
-   req := r.clientset.CoreV1().Pods(pod.Namespace).GetLogs(pod.Name, &corev1.PodLogOptions{})
-   podLogs, err := req.Stream(ctx)
-   if err != nil {
-       log.Error(err, "unable to stream pod logs")
-       return err
-   }
-   defer podLogs.Close()
-   // Check if the log message exists in the pod logs
-   buf := make([]byte, 2000)
-   _, err = podLogs.Read(buf)
-   if err != nil {
-       log.Error(err, "error reading pod logs")
-       return err
-   }
-   logStr := string(buf)
-   if strings.Contains(logStr, logMessage) {
-       log.Info("Found the specified log message, restarting pod")
-       // Restart the pod by deleting it (will be recreated by deployment/statefulset/etc.)
-       err = r.clientset.CoreV1().Pods(pod.Namespace).Delete(ctx, pod.Name, metav1.DeleteOptions{})
-       if err != nil {
-           log.Error(err, "unable to delete pod", "pod", pod.Name)
-           return err
-       }
-       log.Info("Pod restarted", "pod", pod.Name)
-       // Update the PodLogMonitor status
-       podLogMonitor.Status.LastRestartedPodName = pod.Name
-       podLogMonitor.Status.LastRestartTime = metav1.NewTime(time.Now())
+	logger := log.FromContext(ctx).WithValues("podlogmonitor", pod)
 
-                if err := r.Status().Update(ctx, podLogMonitor); err != nil {
-           log.Error(err, "unable to update PodLogMonitor status")
-           return err
-       }
-   }
-   return nil
+	// Check if we have the clientset; if not, create it
+	if r.clientset == nil {
+		logger.Info("Creating a new clientset...")
+		config, err := rest.InClusterConfig()
+		if err != nil {
+			logger.Error(err, "unable to create in-cluster config")
+			return err
+		}
+		clientset, err := kubernetes.NewForConfig(config)
+		if err != nil {
+			logger.Error(err, "unable to create Kubernetes clientset")
+			return err
+		}
+		r.clientset = clientset
+	}
+	// Get the logs of the pod using the Kubernetes API
+	req := r.clientset.CoreV1().Pods(pod.Namespace).GetLogs(pod.Name, &corev1.PodLogOptions{})
+	podLogs, err := req.Stream(ctx)
+	if err != nil {
+		logger.Error(err, "unable to stream pod logs")
+		return err
+	}
+	defer podLogs.Close()
+	// Check if the log message exists in the pod logs
+	buf := make([]byte, 2000)
+	_, err = podLogs.Read(buf)
+	if err != nil {
+		logger.Error(err, "error reading pod logs")
+		return err
+	}
+	logStr := string(buf)
+	if strings.Contains(logStr, logMessage) {
+		logger.Info("Found the specified log message, restarting pod")
+		// Restart the pod by deleting it (will be recreated by deployment/statefulset/etc.)
+		err = r.clientset.CoreV1().Pods(pod.Namespace).Delete(ctx, pod.Name, metav1.DeleteOptions{})
+		if err != nil {
+			logger.Error(err, "unable to delete pod", "pod", pod.Name)
+			return err
+		}
+		logger.Info("Pod restarted", "pod", pod.Name)
+		// Update the PodLogMonitor status
+		podLogMonitor.Status.LastRestartedPodName = pod.Name
+		podLogMonitor.Status.LastRestartTime = metav1.NewTime(time.Now())
+
+		if err := r.Status().Update(ctx, podLogMonitor); err != nil {
+			logger.Error(err, "unable to update PodLogMonitor status")
+			return err
+		}
+	}
+	return nil
 }
-
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *PodLogMonitorReconciler) SetupWithManager(mgr ctrl.Manager) error {
-        return ctrl.NewControllerManagedBy(mgr).
-                For(&monitoringv1.PodLogMonitor{}).
-                Complete(r)
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&monitoringv1.PodLogMonitor{}).
+		Complete(r)
 }

--- a/rbac.yaml
+++ b/rbac.yaml
@@ -1,0 +1,63 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: podlogmonitor-svc
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: podlogmonitor-role
+  creationTimestamp: null
+rules:
+- apiGroups:
+  - monitoring.mydomain.com
+  resources:
+  - podlogmonitors
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - monitoring.mydomain.com
+  resources:
+  - podlogmonitors/status
+  verbs:
+  - get
+  - update
+  - patch
+- apiGroups:
+  - monitoring.mydomain.com
+  resources:
+  - podlogmonitors/finalizers
+  verbs:
+  - update
+- apiGroups: [""]
+  resources:
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups: [""]
+  resources:
+  - pods/log
+  verbs:
+  - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: podlogmonitor-system-default
+subjects:
+- kind: ServiceAccount
+  name: podlogmonitor-svc
+  namespace: default
+roleRef:
+  kind: ClusterRole
+  name: podlogmonitor-role
+  apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
You were on the right track. Here's what I did:

- Switched to the package-level `log` instead of the one in the reconciler implementation. This fixed logging.
- Switched back to listing pods with the `client.InNamespace(podLogMonitor.Spec.Namespace)` option.
- Removed the additional status update logic in `Reconcile(...)` after the `checkPodLogs()` loop.

I also changed the `Dockerfile` to use cross-platform builds, added an  RBAC definition (for testing) and ran `go fmt`.